### PR TITLE
 Add the ability to use game specific settings

### DIFF
--- a/GameIndex.txt
+++ b/GameIndex.txt
@@ -18099,7 +18099,7 @@ Name   = Astro Boy - The Video Game
 Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55605
-Name   = Naruto Shipuuden - Ultimate Ninja 5
+Name   = Naruto Shippuden - Ultimate Ninja 5
 Region = PAL-M5
 Compat = 5
 ---------------------------------------------

--- a/README.md
+++ b/README.md
@@ -22,3 +22,12 @@ Download this repository, name it "ps2_1e814707-1fe3-4e1e-86fe-1b8d1b7fac2e" and
 1. When you have an account go here: https://www.giantbomb.com/api/
 2. Place a file named "config.py" in your installation folder with a single line:
     * api_key = YOUR_KEY_GOES_HERE_IN_QUOTES i.e. api_key = "abcdefghijklmnopqrstuvwxyz"
+    
+### Game specific settings
+
+1. Create a folder named "configs" inside "Documents/PCSX2" (the folder containing your bios, savestates etc.).
+2. Put the path to that folder into user_config.py and enable the feature by setting emu_config = True
+3. To create settings for a game, copy the "inis" or "inis_1.4.0" folder into the "configs" folder and rename it to match the rom.
+   Make sure that the renamed folders have the same name as the corresponding rom without the extension.
+   eg. ROM: "Shadow of the Colossus.iso" | FOLDER: "Shadow of the Colossus"
+   Without a specific config folder for a game, the default settings will be used.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A PS2 integration for GOG Galaxy 2.0
 ## Features
 * Looks for iso and gz files in a folder you specify
 * Supports launching games with PCSX2
+* Supports the usage of game specific settings
 
 ## Installation and Config
 

--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,7 @@
 import asyncio
 import subprocess
 import sys
+import os
 
 import user_config
 from backend import BackendClient
@@ -42,9 +43,10 @@ class PlayStation2Plugin(Plugin):
 
         for game in self.games:
             if str(game[1]) == game_id:
-                if config:
-                    config_arg = '--cfgpath=' + config_folder + "/" + game[2]
-                    
+                rom_file = os.path.splitext(os.path.basename(game[0]))[0]
+                config_folder_game = config_folder + "/" + rom_file
+                if config and os.path.isdir(config_folder_game):
+                    config_arg = '--cfgpath=' + config_folder + "/" + rom_file
                     if no_gui and fullscreen:
                         subprocess.Popen([emu_path, "--nogui", "--fullscreen", config_arg, game[0]])
                         break

--- a/plugin.py
+++ b/plugin.py
@@ -37,20 +37,37 @@ class PlayStation2Plugin(Plugin):
         emu_path = user_config.emu_path
         no_gui = user_config.emu_no_gui
         fullscreen = user_config.emu_fullscreen
-        
+        config = user_config.emu_config
+        config_folder = user_config.config_path
+
         for game in self.games:
             if str(game[1]) == game_id:
-                if no_gui and fullscreen:
-                    subprocess.Popen([emu_path, "--nogui", "--fullscreen", game[0]])
+                if config:
+                    config_arg = '--cfgpath=' + config_folder + "/" + game[2]
+                    
+                    if no_gui and fullscreen:
+                        subprocess.Popen([emu_path, "--nogui", "--fullscreen", config_arg, game[0]])
+                        break
+                    if no_gui and not fullscreen:
+                        subprocess.Popen([emu_path, "--nogui", config_arg, game[0]])
+                        break
+                    if not no_gui and fullscreen:
+                        subprocess.Popen([emu_path, "--fullscreen", config_arg, game[0]])
+                        break
+                    subprocess.Popen([emu_path, config_arg, game[0]])
                     break
-                if no_gui and not fullscreen:
-                    subprocess.Popen([emu_path, "--nogui", game[0]])
+                else:
+                    if no_gui and fullscreen:
+                        subprocess.Popen([emu_path, "--nogui", "--fullscreen", game[0]])
+                        break
+                    if no_gui and not fullscreen:
+                        subprocess.Popen([emu_path, "--nogui", game[0]])
+                        break
+                    if not no_gui and fullscreen:
+                        subprocess.Popen([emu_path, "--fullscreen", game[0]])
+                        break
+                    subprocess.Popen([emu_path, game[0]])
                     break
-                if not no_gui and fullscreen:
-                    subprocess.Popen([emu_path, "--fullscreen", game[0]])
-                    break
-                subprocess.Popen([emu_path, game[0]])
-                break
         return
 
     async def install_game(self, game_id):

--- a/user_config.py
+++ b/user_config.py
@@ -12,8 +12,10 @@ emu_fullscreen = False
 use_database = True
 # Set to True if you want to use game specific configurations
 emu_config = False
-# Select your Documents/PCSX2/configs folder containing your game specific configurations.
-# Make sure that the contained folders have the same name as the corresponding rom without the extension.
+# To use this feature, create a folder named "configs" inside "Documents/PCSX2" (the folder containing your bios, savestates etc.)
+# Put the path to that folder down below
+# To create settings for a game, copy the "inis" or "inis_1.4.0" folder into the "configs" folder and rename it to match the rom.
+# Make sure that the renamed folders have the same name as the corresponding rom without the extension.
 # eg. ROM: "Shadow of the Colossus.iso" | FOLDER: "Shadow of the Colossus"
 # Without a specific config folder for a game, the default settings will be used.
 config_path = "D:/Documents/PCSX2/configs"

--- a/user_config.py
+++ b/user_config.py
@@ -1,10 +1,19 @@
+# Make sure to use / instead of \ in file paths.
+
 # Set your roms folder here
-roms_path = "F:/Games/PS2"
+roms_path = "S:/Playstation 2/ISOs"
 # Set the path to your pcsx2.exe here
-emu_path = "E:/Programs/Emulators/pcsx2-v1.5.0-dev-3218/pcsx2.exe"
+emu_path = "P:/PCSX2 1.4.0/pcsx2.exe"
 # Set to True if you want to suppress the gui when launching a game
 emu_no_gui = False
 # Set to True if you want to launch in fullscreen by default
 emu_fullscreen = False
-# Decide whether to use the PCSX2 game database or Giant Bomb
+# Decide whether to use the PCSX2 game database (True) or Giant Bomb (False)
 use_database = True
+# Set to True if you want to use game specific configurations
+emu_config = False
+# Select your Documents/PCSX2/configs folder containing your game specific configurations.
+# Make sure that the contained folders have the same name as the corresponding rom without the extension.
+# eg. ROM: "Shadow of the Colossus.iso" | FOLDER: "Shadow of the Colossus"
+# Without a specific config folder for a game, the default settings will be used.
+config_path = "D:/Documents/PCSX2/configs"


### PR DESCRIPTION
This basically applies the --cfgpath="path" argument on game launch if the feature is enabled, allowing the usage of different settings for individual games.