### PR TITLE
Use random TCP port instead of 8080

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -56,9 +56,10 @@ class AuthenticationServer(threading.Thread):
     def __init__(self):
         super().__init__()
         self.path = ""
-        server_address = ('localhost', 8080)
+        server_address = ('localhost', 0)
         self.httpd = HTTPServer(server_address, AuthenticationHandler)
         self.port = self.httpd.server_port
+        logging.debug("DEV: Authentication server started on port %s", self.port)
 
     def run(self):
         self.httpd.serve_forever()


### PR DESCRIPTION
Currently, the plugin messes with other tools that might want to use the 8080 port (many development web servers). Since GOG Galaxy only runs on Windows, we can use 0 instead, which [instructs the OS to assign a random port](https://web.archive.org/web/20190516191849/https://cs.nyu.edu/bacon/phd-thesis/diss/node29.html#SECTION00713000000000000000#:~:text=requesting%20port%200,%20which%20instructs%20the%20system%20to%20choose%20an%20ephemeral%20port%20number), which we then can get back from the socket instance.

Ideally, the authentication server would not run at all unless we're actually in the setup sequence, but at least decoupling it from a known port number should be a good first step.